### PR TITLE
docker-compose: Fix dapr components path for merged docker-compose files

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,7 +39,7 @@ services:
       "--resources-path", "./components"
     ]
     volumes:
-      - "./components/:/components" # Mount our components folder for the runtime to use. The mounted location must match the --resources-path argument.
+      - "./../flashcard_service/components/:/components" # Mount our components folder for the runtime to use. The mounted location must match the --resources-path argument.
     depends_on:
       - app-flashcard
       - redis


### PR DESCRIPTION
Quick workaround because docker does not resolve paths correctly when using its function to merge multiple compose files