### PR TITLE
Add RequestHeaderUserInterceptor

### DIFF
--- a/src/main/java/de/unistuttgart/iste/gits/flashcard_service/config/RequestHeaderUserInterceptor.java
+++ b/src/main/java/de/unistuttgart/iste/gits/flashcard_service/config/RequestHeaderUserInterceptor.java
@@ -1,0 +1,24 @@
+package de.unistuttgart.iste.gits.flashcard_service.config;
+
+import de.unistuttgart.iste.gits.common.user_handling.RequestHeaderUserProcessor;
+import lombok.SneakyThrows;
+import org.jetbrains.annotations.NotNull;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.graphql.server.WebGraphQlInterceptor;
+import org.springframework.graphql.server.WebGraphQlRequest;
+import org.springframework.graphql.server.WebGraphQlResponse;
+import reactor.core.publisher.Mono;
+
+/**
+ * This class is used to add data from the request headers to the GraphQL context.
+ */
+@Configuration
+public class RequestHeaderUserInterceptor implements WebGraphQlInterceptor {
+    @NotNull
+    @Override
+    @SneakyThrows
+    public Mono<WebGraphQlResponse> intercept(@NotNull WebGraphQlRequest request, @NotNull Chain chain) {
+        RequestHeaderUserProcessor.process(request);
+        return chain.next(request);
+    }
+}


### PR DESCRIPTION
Adds a request interceptor that injects the user data into the GraphQL context. Same code as in all the other services.