### PR TITLE
make flashcard set query work consistently

### DIFF
--- a/src/main/java/de/unistuttgart/iste/gits/flashcard_service/controller/FlashcardController.java
+++ b/src/main/java/de/unistuttgart/iste/gits/flashcard_service/controller/FlashcardController.java
@@ -1,12 +1,13 @@
 package de.unistuttgart.iste.gits.flashcard_service.controller;
 
+import de.unistuttgart.iste.gits.common.user_handling.LoggedInUser;
 import de.unistuttgart.iste.gits.flashcard_service.service.FlashcardService;
 import de.unistuttgart.iste.gits.flashcard_service.service.FlashcardUserProgressDataService;
 import de.unistuttgart.iste.gits.generated.dto.*;
-import de.unistuttgart.iste.gits.common.user_handling.LoggedInUser;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.graphql.data.method.annotation.*;
 import org.springframework.stereotype.Controller;
+
 import java.util.List;
 import java.util.UUID;
 
@@ -30,8 +31,8 @@ public class FlashcardController {
     }
 
     @QueryMapping
-    public List<FlashcardSet> flashcardSetsByAssessmentIds(@Argument(name = "assessmentIds") List<UUID> ids) {
-        return flashcardService.getFlashcardSetsByAssessmentId(ids);
+    public List<FlashcardSet> findFlashcardSetsByAssessmentIds(@Argument(name = "assessmentIds") List<UUID> ids) {
+        return flashcardService.findFlashcardSetsByAssessmentId(ids);
     }
 
     @SchemaMapping(typeName = "Flashcard", field = "userProgressData")

--- a/src/main/java/de/unistuttgart/iste/gits/flashcard_service/persistence/repository/FlashcardSetRepository.java
+++ b/src/main/java/de/unistuttgart/iste/gits/flashcard_service/persistence/repository/FlashcardSetRepository.java
@@ -5,11 +5,9 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.stereotype.Repository;
 
-import java.util.List;
 import java.util.UUID;
 
 @Repository
 public interface FlashcardSetRepository extends JpaRepository<FlashcardSetEntity, UUID>,
         JpaSpecificationExecutor<FlashcardSetEntity> {
-    List<FlashcardSetEntity> findByAssessmentIdIn(List<UUID> ids);
 }

--- a/src/main/java/de/unistuttgart/iste/gits/flashcard_service/service/FlashcardService.java
+++ b/src/main/java/de/unistuttgart/iste/gits/flashcard_service/service/FlashcardService.java
@@ -64,7 +64,7 @@ public class FlashcardService {
 
     public UUID deleteFlashcard(UUID assessmentId, UUID flashcardId) {
         FlashcardSetEntity set = flashcardSetRepository.getReferenceById(assessmentId);
-        if(!set.getFlashcards().removeIf(x -> x.getId().equals(flashcardId))) {
+        if (!set.getFlashcards().removeIf(x -> x.getId().equals(flashcardId))) {
             throw new EntityNotFoundException("Flashcard with id " + flashcardId + " not found.");
         }
         flashcardSetRepository.save(set);
@@ -111,10 +111,17 @@ public class FlashcardService {
                 .toList();
     }
 
-    public List<FlashcardSet> getFlashcardSetsByAssessmentId(List<UUID> ids) {
-        return flashcardSetRepository.findByAssessmentIdIn(ids)
-                .stream()
-                .map(flashcardMapper::flashcardSetEntityToDto)
+    /**
+     * Returns all flashcard sets that are linked to the given assessment ids
+     *
+     * @param ids list of assessment ids
+     * @return list of flashcard sets, an element is null if the corresponding assessment id was not found
+     */
+    public List<FlashcardSet> findFlashcardSetsByAssessmentId(List<UUID> ids) {
+        return ids.stream()
+                .map(flashcardSetRepository::findById)
+                .map(optional -> optional.map(flashcardMapper::flashcardSetEntityToDto))
+                .map(optional -> optional.orElse(null))
                 .toList();
     }
     /**

--- a/src/main/resources/graphql/query.graphqls
+++ b/src/main/resources/graphql/query.graphqls
@@ -6,6 +6,7 @@ type Query {
     """
     Get flashcard sets by their assessment ids.
     Returns a list of flashcard sets in the same order as the provided ids.
+    Each element is null if the corresponding id is not found.
     """
-    flashcardSetsByAssessmentIds(assessmentIds: [UUID!]!): [FlashcardSet!]!
+    findFlashcardSetsByAssessmentIds(assessmentIds: [UUID!]!): [FlashcardSet]!
 }


### PR DESCRIPTION
## Description of changes
Make it consistent with other services and not fail if a flashcard set doesn't exist

  
## How has this been tested?

Please describe the test strategy you followed. If not tested, please explain why.

- [ ] automated unit test
- [x] automated integration test
- [ ] manual, exploratory test

In case of manual test, please document the test well including a set of user instructions and prerequisites. Each including an action, it's result, and where appropriate a screenshot.
    
## Checklist before requesting a review

- [ ] My code is easy to understand
- [ ] My code follows the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of this project
- [ ] My code fulfills all acceptance criteria
- [ ] The test coverage (line and branch) is reasonably high, especially on Service classes and other classes with complex logic
- [ ] I have made corresponding changes to the documentation or
  the [wiki/adr](https://github.com/IT-REX-Platform/wiki/tree/main/adr)
- [ ] I made no breaking changes in the database schema or if so, I will perform a database migration

## Checklist for reviewer

- The code is easy to understand
- The code follows
  the [coding guidelines](https://github.com/IT-REX-Platform/wiki/blob/main/dev-manuals/backend/coding-guidelines.md) of
  this project
- The code is tested or if not, the reason is documented or discussed
- The added and existing tests reasonably cover the code change
- The code has no breaking changes in the database schema or if so, the assignee is aware of it and
  will perform a database migration
